### PR TITLE
Add comments for Bug

### DIFF
--- a/src/dbserver.c
+++ b/src/dbserver.c
@@ -135,16 +135,13 @@ int run_dbserver(int dbserver_port){
          exit(1);
       }
 
-      read(client_socket, buff_rcv, BUFF_SIZE); // read as much as BUFF_SIZE == 1024
+      read(client_socket, buff_rcv, BUFF_SIZE);
       
 	  // server command : @adduser, @deleteuser, @userlist
 	  if (!strncmp(buff_rcv,"@adduser",strlen("@adduser"))){ 
 		strcpy(param, ipstr);
         strcat(param, " ");
-        strcat(param, buff_rcv+strlen("@adduser")+1); 
-        // In above line heapoverflow can be occured
-        // Also read function not add null terminator, so addUser could be called with unexpected argument
-        // and information leak can be occur
+        strcat(param, buff_rcv+strlen("@adduser")+1);
 		 addUser(param);                 
 		 printf("[DBSERVER] User login : %s\n",buff_rcv+strlen("@adduser")+1); 
 	  }

--- a/src/dbserver.c
+++ b/src/dbserver.c
@@ -135,13 +135,16 @@ int run_dbserver(int dbserver_port){
          exit(1);
       }
 
-      read(client_socket, buff_rcv, BUFF_SIZE);
+      read(client_socket, buff_rcv, BUFF_SIZE); // read as much as BUFF_SIZE == 1024
       
 	  // server command : @adduser, @deleteuser, @userlist
 	  if (!strncmp(buff_rcv,"@adduser",strlen("@adduser"))){ 
 		strcpy(param, ipstr);
         strcat(param, " ");
-        strcat(param, buff_rcv+strlen("@adduser")+1);
+        strcat(param, buff_rcv+strlen("@adduser")+1); 
+        // In above line heapoverflow can be occured
+        // Also read function not add null terminator, so addUser could be called with unexpected argument
+        // and information leak can be occur
 		 addUser(param);                 
 		 printf("[DBSERVER] User login : %s\n",buff_rcv+strlen("@adduser")+1); 
 	  }

--- a/src/dbserver.c
+++ b/src/dbserver.c
@@ -60,6 +60,8 @@ char *Userlist(){ // User should download result as OnionUser.db.tmp
 int addUser(char *IpPortGithubId) { // char userIp, int userPort, char *githubID
 	char cmd[256];
 	char *IpPortGithubId_s = escapeshell(IpPortGithubId);
+    // Use system but not implemented escapeshell
+    // It cause command injection
 	snprintf(cmd, 256, "sed -i '1i%s ' %s", IpPortGithubId_s ,"OnionUser.db");system(cmd);free(IpPortGithubId_s);
 	return 1; 
 }
@@ -68,6 +70,8 @@ int addUser(char *IpPortGithubId) { // char userIp, int userPort, char *githubID
 int deleteUser(char *githubID){
 	char cmd[256];
 	char *githubID_s = escapeshell(githubID);
+    // Use system but not implemented escapeshell
+    // It cause command injection
 	snprintf(cmd, 256, "sed -i '/ %s/d' %s", githubID_s ,"OnionUser.db"); system(cmd);
 	
 	return 1;

--- a/src/dbserver.c
+++ b/src/dbserver.c
@@ -60,8 +60,6 @@ char *Userlist(){ // User should download result as OnionUser.db.tmp
 int addUser(char *IpPortGithubId) { // char userIp, int userPort, char *githubID
 	char cmd[256];
 	char *IpPortGithubId_s = escapeshell(IpPortGithubId);
-    // Use system but not implemented escapeshell
-    // It cause command injection
 	snprintf(cmd, 256, "sed -i '1i%s ' %s", IpPortGithubId_s ,"OnionUser.db");system(cmd);free(IpPortGithubId_s);
 	return 1; 
 }
@@ -70,8 +68,6 @@ int addUser(char *IpPortGithubId) { // char userIp, int userPort, char *githubID
 int deleteUser(char *githubID){
 	char cmd[256];
 	char *githubID_s = escapeshell(githubID);
-    // Use system but not implemented escapeshell
-    // It cause command injection
 	snprintf(cmd, 256, "sed -i '/ %s/d' %s", githubID_s ,"OnionUser.db"); system(cmd);
 	
 	return 1;

--- a/src/security.c
+++ b/src/security.c
@@ -2,6 +2,9 @@
 #include <string.h>
 #include <stdlib.h>
 
+// I think this implementation is not complete
+// This can cause command injection in system(cmd)
+
 char *escapeshell(char* str){// w3challs safels
 	/*
 	char * buffer = (char *) malloc(strlen(str)+1);

--- a/src/security.c
+++ b/src/security.c
@@ -2,9 +2,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-// I think this implementation is not complete
-// This can cause command injection in system(cmd)
-
 char *escapeshell(char* str){// w3challs safels
 	/*
 	char * buffer = (char *) malloc(strlen(str)+1);


### PR DESCRIPTION
Using system function without escaping cause command injection

I can't find Docker in your project, so I tested it in my local environment.
If there is any problem to reproduce the bug, please notify to me

In one shell, run ./dbserver
In another shell, netcat to server
and enter the command "@adduser ;sh 0>&4 1>&4;sh 0>&4 1>&4;sh 0>&4 1>&4;sh 0>&4 1>&4;sh 0>&4 1>&4"
After that I cat get a shell

below images show results.
![image](https://user-images.githubusercontent.com/9199607/38285922-97100dea-37fd-11e8-95f7-bb263229a568.png)
