### PR TITLE
Heapoverflow

### DIFF
--- a/src/dbserver.c
+++ b/src/dbserver.c
@@ -135,13 +135,16 @@ int run_dbserver(int dbserver_port){
          exit(1);
       }
 
-      read(client_socket, buff_rcv, BUFF_SIZE);
+      read(client_socket, buff_rcv, BUFF_SIZE); // read as much as BUFF_SIZE == 1024
       
 	  // server command : @adduser, @deleteuser, @userlist
 	  if (!strncmp(buff_rcv,"@adduser",strlen("@adduser"))){ 
 		strcpy(param, ipstr);
         strcat(param, " ");
-        strcat(param, buff_rcv+strlen("@adduser")+1);
+        strcat(param, buff_rcv+strlen("@adduser")+1); 
+        // In above line heapoverflow can be occured
+        // Also read function not add null terminator, so addUser could be called with unexpected argument
+        // and information leak can be occur
 		 addUser(param);                 
 		 printf("[DBSERVER] User login : %s\n",buff_rcv+strlen("@adduser")+1); 
 	  }

--- a/src/dbserver.c
+++ b/src/dbserver.c
@@ -60,6 +60,8 @@ char *Userlist(){ // User should download result as OnionUser.db.tmp
 int addUser(char *IpPortGithubId) { // char userIp, int userPort, char *githubID
 	char cmd[256];
 	char *IpPortGithubId_s = escapeshell(IpPortGithubId);
+    // Use system but not implemented escapeshell
+    // It cause command injection
 	snprintf(cmd, 256, "sed -i '1i%s ' %s", IpPortGithubId_s ,"OnionUser.db");system(cmd);free(IpPortGithubId_s);
 	return 1; 
 }
@@ -68,6 +70,8 @@ int addUser(char *IpPortGithubId) { // char userIp, int userPort, char *githubID
 int deleteUser(char *githubID){
 	char cmd[256];
 	char *githubID_s = escapeshell(githubID);
+    // Use system but not implemented escapeshell
+    // It cause command injection
 	snprintf(cmd, 256, "sed -i '/ %s/d' %s", githubID_s ,"OnionUser.db"); system(cmd);
 	
 	return 1;

--- a/src/dbserver.c
+++ b/src/dbserver.c
@@ -60,8 +60,6 @@ char *Userlist(){ // User should download result as OnionUser.db.tmp
 int addUser(char *IpPortGithubId) { // char userIp, int userPort, char *githubID
 	char cmd[256];
 	char *IpPortGithubId_s = escapeshell(IpPortGithubId);
-    // Use system but not implemented escapeshell
-    // It cause command injection
 	snprintf(cmd, 256, "sed -i '1i%s ' %s", IpPortGithubId_s ,"OnionUser.db");system(cmd);free(IpPortGithubId_s);
 	return 1; 
 }
@@ -70,8 +68,6 @@ int addUser(char *IpPortGithubId) { // char userIp, int userPort, char *githubID
 int deleteUser(char *githubID){
 	char cmd[256];
 	char *githubID_s = escapeshell(githubID);
-    // Use system but not implemented escapeshell
-    // It cause command injection
 	snprintf(cmd, 256, "sed -i '/ %s/d' %s", githubID_s ,"OnionUser.db"); system(cmd);
 	
 	return 1;

--- a/src/security.c
+++ b/src/security.c
@@ -2,6 +2,9 @@
 #include <string.h>
 #include <stdlib.h>
 
+// I think this implementation is not complete
+// This can cause command injection in system(cmd)
+
 char *escapeshell(char* str){// w3challs safels
 	/*
 	char * buffer = (char *) malloc(strlen(str)+1);

--- a/src/security.c
+++ b/src/security.c
@@ -2,9 +2,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-// I think this implementation is not complete
-// This can cause command injection in system(cmd)
-
 char *escapeshell(char* str){// w3challs safels
 	/*
 	char * buffer = (char *) malloc(strlen(str)+1);


### PR DESCRIPTION
There is a heap overflow bug in https://github.com/khsdo95/2018s-onion-team1/blob/heapoverflow/src/dbserver.c#L140-L143

```
read(client_socket, buff_rcv, BUFF_SIZE); // read as much as BUFF_SIZE == 1024
...
strcat(param, buff_rcv+strlen("@adduser")+1);
```

param is 512-byte, dynamic allocated buffer in heap
BUFF_SIZE is 1024
Therefore, heap overflow can be occurred.

![image](https://user-images.githubusercontent.com/9199607/38288284-bc33e210-380a-11e8-92c8-6a31435469cc.png)

This image shows that the userlist command returns with previous input, because they use also heap.

