### PR TITLE
Format string bug

### DIFF
--- a/src/dvonion.c
+++ b/src/dvonion.c
@@ -113,7 +113,8 @@ void draw_list_window(){
             name = strchr(buf, ' ') + 1;   // second space.
             trim(name);
             lock++;
-            mvwprintw(win, 1+i, 1, name);
+            //XXX : FSB
+            mvwprintw(win, 1+i, 1, "%s", name);
             box(win, 0, 0);
             wrefresh(win);
             lock--;
@@ -133,7 +134,8 @@ void draw_server_window(){
         lock++;
         tmp = g_head;
         while(tmp != 0){
-            mvwprintw(win, 1+i, 1, tmp->msg);
+            //XXX: FSB
+            mvwprintw(win, 1+i, 1, "%s", tmp->msg);
             
             i++;
             tmp = tmp->next;
@@ -352,7 +354,8 @@ char* get_input(WINDOW* win){
             if(!lock){
                 lock++;
                 box(win, 0, 0);
-                mvwprintw(win, 1, 1, buf);
+            // XXX: FSB
+                mvwprintw(win, 1, 1, "%s", buf);
                 wrefresh(win);
                 lock--;
             }
@@ -363,7 +366,8 @@ char* get_input(WINDOW* win){
         if(!lock){
             lock++;
             box(win, 0, 0);
-            mvwprintw(win, 1, 1, buf);
+            // XXX: FSB
+            mvwprintw(win, 1, 1, "%s", buf);
             wrefresh(win);
             lock--;
         }


### PR DESCRIPTION

Your program has Format string bug vulnerabilty.

When user input %s to the input box, It occur Format string bug.

I just make crash input to write poc.

When I typed %s%s%s to messenger input, the messenger crashed due to the invalid memory access.


Also, when attacker send FSB payload as message, he can fully hijack control flow of your program.

You can figure out it is remote code execution vulnerability.


Below image is local crash POC.

<img width="723" alt="2018-04-06 14 04 03" src="https://user-images.githubusercontent.com/11594091/38404216-673aa092-39a3-11e8-92be-1b7017d1932a.png">





